### PR TITLE
Add gateway Brewfile casks with greedy updates

### DIFF
--- a/.Brewfile-base
+++ b/.Brewfile-base
@@ -21,6 +21,7 @@ else
   brew "mole"
 end
 
+cask "gateway-brewfile-base", greedy: true if cask_installed?("gateway-brewfile-base")
 cask "bevanjkay/tap/zsh-autosuggestions-static"
 cask "bevanjkay/tap/zsh-syntax-highlighting-static"
 cask "font-sf-mono"

--- a/.Brewfile-kiosk
+++ b/.Brewfile-kiosk
@@ -2,6 +2,7 @@
 instance_eval(File.read(File.join(__dir__, ".Brewfile-base")))
 
 # Kiosk
+cask "gateway-brewfile-kiosk", greedy: true
 cask "gatewaymedia/tap/gateway-community-hub"
 cask "bevanjkay/tap/kiosk-browser"
 cask "gatewaymedia/tap/kiosk-browser-settings"

--- a/.Brewfile-production
+++ b/.Brewfile-production
@@ -11,6 +11,7 @@ else
   brew "yt-dlp"
 end
 
+cask "gateway-brewfile-production", greedy: true
 cask "bmd-atem"
 cask "bmd-videohub"
 cask "dante-controller"


### PR DESCRIPTION
## Summary
- add gateway-brewfile-kiosk to .Brewfile-kiosk with greedy: true
- add gateway-brewfile-production to .Brewfile-production with greedy: true
- add guarded base entry to .Brewfile-base so gateway-brewfile-base is only included when already installed (if cask_installed?("gateway-brewfile-base"))

## Validation
- ruby -c .Brewfile-base
- ruby -c .Brewfile-kiosk
- ruby -c .Brewfile-production